### PR TITLE
add create2 support for contract deploys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ artifacts
 # Coverage Report
 report/
 lcov.info
+src/evm/contracts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymerdao/prover-contracts",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "main": "dist/index.js",
   "bin": {
     "verify-prover-contracts": "./dist/scripts/verify-contract-script.js",

--- a/src/scripts/update-contracts-script.ts
+++ b/src/scripts/update-contracts-script.ts
@@ -8,8 +8,14 @@ import { UPDATE_SPECS_PATH } from "../utils/constants";
 import { parseArgsFromCLI } from "../utils/io";
 
 async function main() {
-  const { chain, accounts, args, extraBindingsPath, externalContractsPath } =
-    await parseArgsFromCLI();
+  const {
+    chain,
+    accounts,
+    args,
+    extraBindingsPath,
+    externalContractsPath,
+    create2Salt,
+  } = await parseArgsFromCLI();
   const updateSpecs = (args.UPDATE_SPECS_PATH as string) || UPDATE_SPECS_PATH;
 
   const contractUpdates = loadContractUpdateRegistry(
@@ -42,6 +48,7 @@ async function main() {
       forceDeployNewContracts: false,
       writeContracts: true,
       extraContractFactories: extraContractFactories ?? undefined,
+      create2Salt,
     }
   );
 }

--- a/src/updateContract.ts
+++ b/src/updateContract.ts
@@ -17,7 +17,8 @@ type UpdateContractsOpts = {
   forceDeployNewContracts?: boolean;
   writeContracts?: boolean;
   extraContractFactories?: Record<string, object>;
-}
+  create2Salt?: string;
+};
 
 // Combination of sendTxToChain and deployContracts. Can do both from a single deploy file, and uses zod to parse the schema.
 export async function updateContractsForChain(
@@ -31,6 +32,7 @@ export async function updateContractsForChain(
     forceDeployNewContracts: false, // True if you want to use existing deployments when possible
     writeContracts: true, // True if you want to save persisted artifact files.
     extraContractFactories: {},
+    create2Salt: undefined,
   }
 ) {
   const {
@@ -38,6 +40,7 @@ export async function updateContractsForChain(
     forceDeployNewContracts,
     writeContracts,
     extraContractFactories,
+    create2Salt,
   } = options;
 
   logger.info(
@@ -84,7 +87,8 @@ export async function updateContractsForChain(
         writeContracts,
         extraContractFactories,
         nonces,
-        env
+        env,
+        create2Salt
       );
       result.set(deployed.name, deployed);
       continue;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -8,9 +8,12 @@ export const DEFAULT_RPC_URL = "http://127.0.0.1:8545";
 export const DEFAULT_CHAIN_ID = "31337";
 export const DEFAULT_CHAIN_NAME = "local";
 export const DEFAULT_VERIFIER = "blockscout";
+export const CREATE_2_FACTORY = "0x4e59b44847b379578588920cA78FbF26c0B4956C";
 export const MODULE_ROOT_PATH =
   process.env.MODULE_ROOT_PATH || path.resolve(__dirname, "..", ".."); // Note: this is impacted by the tsup config since that can potential change where this file ends up being built to
-export const PARENT_MODULE_ROOT_PATH = path.dirname(path.resolve("package.json")); // Path of module using this package; path.resolve uses cwd so this should typically be the root of the module that's running the bin
+export const PARENT_MODULE_ROOT_PATH = path.dirname(
+  path.resolve("package.json")
+); // Path of module using this package; path.resolve uses cwd so this should typically be the root of the module that's running the bin
 const DEFAULT_ARTIFACTS_PATH = path.resolve(MODULE_ROOT_PATH, "out");
 const DEFAULT_DEPLOYMENTS_PATH = path.resolve(
   PARENT_MODULE_ROOT_PATH,
@@ -55,3 +58,6 @@ export const EXTRA_ARTIFACTS_PATH = process.env.EXTRA_ARTIFACTS_PATH;
 
 // Path where we can load an existing contract registry from 
 export const EXTERNAL_CONTRACTS_PATH= process.env.EXTERNAL_CONTRACTS_PATH;
+
+// Create2 salt for create2 deployments 
+export const CREATE2_SALT = process.env.CREATE2_SALT;


### PR DESCRIPTION
Add deterministic address deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added support for CREATE2 contract deployment with optional salt parameter
  - Enhanced contract deployment flexibility

- **Chores**
  - Updated package version to 0.0.12
  - Improved code formatting and import consistency

- **Configuration**
  - Added new constants for CREATE2 factory and deployment salt
  - Updated `.gitignore` to exclude specific contract directories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->