### PR TITLE
Fix Typos in Comments

### DIFF
--- a/contracts/examples/Venus.sol
+++ b/contracts/examples/Venus.sol
@@ -133,7 +133,7 @@ contract Venus {
             revert invalidCounterpartyEvent();
         }
 
-        // Now that we have verified the event type and the sender is correct, we can trust the log itself occured from
+        // Now that we have verified the event type and the sender is correct, we can trust the log itself occurred from
         // a smart contract we are familiar with. All that is left to do is to unpack the args and use them.
 
         // The abi encoded string is the only indexed arg, it will be the second arg in the topics, we can store it in

--- a/test/prove_api/Repro.t.sol
+++ b/test/prove_api/Repro.t.sol
@@ -23,7 +23,7 @@ import {SequencerSignatureVerifier} from "../../contracts/core/prove_api/Sequenc
 contract ContractDebugReproTest is Test {
     bytes clientUpdate; // the contract client update which will update the peptide hash that the verify receipt proof
         // can use
-    bytes receiptProof; // Used to test any reciept proof. The hex encoded version of what is returned from a completed
+    bytes receiptProof; // Used to test any receipt proof. The hex encoded version of what is returned from a completed
         // proof api job.
 
     // Values currently deployed for devnet


### PR DESCRIPTION


Description:  
This pull request corrects spelling mistakes in comments across two files:
- In `contracts/examples/Venus.sol`, the word "occured" has been corrected to "occurred".
- In `test/prove_api/Repro.t.sol`, the word "reciept" has been corrected to "receipt".

These changes improve code readability and maintain consistency in documentation. No functional code has been modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Corrected spelling mistakes in comments to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->