### PR TITLE
fix dead link in tsup.config.ts 

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     "src/utils/io.ts",
     "src/utils/constants.ts",
     "src/evm/chain.ts",
-    "src/evm/contracts/*.ts",
+    "src/evm/contracts/index.ts",
     "src/evm/schemas/*.ts",
     "src/scripts/update-contracts-script.ts",
     "src/scripts/verify-contract-script.ts",


### PR DESCRIPTION


**Problem:** The build configuration was referencing non-existent contract files with wildcard imports (`src/evm/contracts/*.ts`), causing build failures.

**Solution:** Replaced wildcard import with specific `index.ts` file reference to ensure proper TypeScript compilation.

## Changes
- Updated `tsup.config.ts` entry point from `"src/evm/contracts/*.ts"` to `"src/evm/contracts/index.ts"`
