### PR TITLE
Reject partial CLI integers

### DIFF
--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -44,10 +44,15 @@ export function CommaOrWhitespaceStrs(value: string) {
  * Arg/Opt: an integer. NaN causes error.
  */
 export function Int(value: string) {
-  const parsed = parseInt(value);
-  if (isNaN(parsed)) {
+  if (!/^-?\d+$/.test(value)) {
     throw new InvalidArgumentError(`invalid integer: ${value}`);
   }
+
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new InvalidArgumentError(`invalid integer: ${value}`);
+  }
+
   return parsed;
 }
 


### PR DESCRIPTION
The shared CLI integer parser used `parseInt`, so values like `123abc` were accepted as `123`. That also affected port parsing because it delegates to the integer parser.

This tightens integer parsing to accept only plain decimal integer strings and rejects unsafe integer values before returning a number.